### PR TITLE
Add preliminary RPM support

### DIFF
--- a/bin/brew2deb
+++ b/bin/brew2deb
@@ -18,7 +18,7 @@ if ARGV.include? 'clean'
 end
 
 $:.unshift File.expand_path('../../lib', __FILE__)
-require 'common_fomrula'
+require 'common_formula'
 require 'debian_formula'
 require 'redhat_formula'
 

--- a/bin/brew2deb
+++ b/bin/brew2deb
@@ -18,7 +18,9 @@ if ARGV.include? 'clean'
 end
 
 $:.unshift File.expand_path('../../lib', __FILE__)
+require 'common_fomrula'
 require 'debian_formula'
+require 'redhat_formula'
 
 Object.__send__ :remove_const, :HOMEBREW_CACHE
 HOMEBREW_WORKDIR = Pathname.new(Dir.pwd)

--- a/lib/common_formula.rb
+++ b/lib/common_formula.rb
@@ -1,0 +1,45 @@
+$:.unshift File.expand_path('../../homebrew/Library/Homebrew', __FILE__)
+require 'tempfile'
+require 'global'
+require 'formula'
+
+class String
+  # Useful for writing indented String and unindent on demand, based on the
+  # first line with indentation.
+  def unindent
+    find_indent = proc{ |l| l.find{|l| !l.strip.empty?}.to_s[/^(\s+)/, 1] }
+
+    lines = self.split("\n")
+    space = find_indent[lines]
+    space = find_indent[lines.reverse] unless space
+
+    strip.gsub(/^#{space}/, '')
+  end
+  alias ui unindent
+
+  # Destructive variant of undindent, replacing the String
+  def unindent!
+    self.replace unindent
+  end
+  alias ui! unindent!
+end
+
+class Formula
+  def self.attr_rw_list(*attrs)
+    attrs.each do |attr|
+      instance_variable_set("@#{attr}", [])
+      class_eval %Q{
+        def self.#{attr}(*list)
+          @#{attr} ||= superclass.respond_to?(:#{attr}) ? superclass.#{attr} : []
+          list.empty? ? @#{attr} : @#{attr} += list
+          @#{attr}.uniq!
+          @#{attr}
+        end
+        def self.#{attr}!(*list)
+          @#{attr} = []
+          #{attr}(*list)
+        end
+      }
+    end
+  end
+end

--- a/lib/redhat_formula.rb
+++ b/lib/redhat_formula.rb
@@ -108,7 +108,7 @@ class RedHatFormula < Formula
 
     unless RUBY_PLATFORM =~ /darwin/
       # Check for build deps.
-      system '/bin/rpm', '-q', f.class.build_depends.join(' '), '/dev/null'
+      system '/bin/rpm', '-q', f.class.build_depends.join(' '), '> /dev/null'
       if $? != 0
         f.send :onoe, 'Missing build dependencies.'
         exit(1)

--- a/lib/redhat_formula.rb
+++ b/lib/redhat_formula.rb
@@ -108,7 +108,7 @@ class RedHatFormula < Formula
 
     unless RUBY_PLATFORM =~ /darwin/
       # Check for build deps.
-      system '/bin/rpm', '-q', f.class.build_depends.join(' ')
+      system "/bin/rpm -q #{f.class.build_depends.join(' ')}"
       if $? != 0
         f.send :onoe, 'Missing build dependencies.'
         exit(1)

--- a/lib/redhat_formula.rb
+++ b/lib/redhat_formula.rb
@@ -108,7 +108,7 @@ class RedHatFormula < Formula
 
     unless RUBY_PLATFORM =~ /darwin/
       # Check for build deps.
-      system '/bin/rpm', '-q', f.class.build_depends.join(',')
+      system '/bin/rpm', '-q', f.class.build_depends.join(' ')
       if $? != 0
         f.send :onoe, 'Missing build dependencies.'
         exit(1)

--- a/lib/redhat_formula.rb
+++ b/lib/redhat_formula.rb
@@ -108,7 +108,7 @@ class RedHatFormula < Formula
 
     unless RUBY_PLATFORM =~ /darwin/
       # Check for build deps.
-      system '/bin/rpm', '-q', f.class.build_depends.join(' '), '> /dev/null'
+      system '/bin/rpm', '-q', f.class.build_depends.join(',')
       if $? != 0
         f.send :onoe, 'Missing build dependencies.'
         exit(1)

--- a/lib/redhat_formula.rb
+++ b/lib/redhat_formula.rb
@@ -108,7 +108,7 @@ class RedHatFormula < Formula
 
     unless RUBY_PLATFORM =~ /darwin/
       # Check for build deps.
-      system "/bin/rpm -q #{f.class.build_depends.join(' ')}"
+      system "/bin/rpm -q #{f.class.build_depends.join(' ')} > /dev/null"
       if $? != 0
         f.send :onoe, 'Missing build dependencies.'
         exit(1)

--- a/packages/credis-rpmtest/formula.rb
+++ b/packages/credis-rpmtest/formula.rb
@@ -1,0 +1,22 @@
+class Credis < RedHatFormula
+  homepage 'http://code.google.com/p/credis/'
+  url 'http://credis.googlecode.com/files/credis-0.2.3.tar.gz'
+  md5 '338c21667ece272d9ab669738e27b191'
+
+  name 'libcredis'
+  section 'devel'
+  version '0.2.3+github1'
+  description 'C client library for redis'
+
+  def build
+    make
+  end
+
+  def install
+    ['libcredis.a', 'libcredis.so'].each do |f|
+      lib.install f
+    end
+    include.install 'credis.h'
+    doc.install 'README'
+  end
+end


### PR DESCRIPTION
brew2deb making RPM's? WHAT?! :)

Could probably cherry pick a few of these changes (notably, could possibly remove credis-rpmtest, but it's a good test to see that it mostly works, so far.)

Had to split apart the libraries in lib/ to separate files, so it's easier to extend (if there's any need for other package managers.)  Also -- added more require statements in the brew2deb binary.
