### PR TITLE
The git formula depends on libssl0.9.8.

### DIFF
--- a/packages/git/formula.rb
+++ b/packages/git/formula.rb
@@ -18,7 +18,8 @@ class Git < DebianFormula
     'libsvn-perl | libsvn-core-perl',
     'unzip',
     'gettext',
-    'libssl-dev'
+    'libssl-dev',
+    'libssl0.9.8'
 
   depends \
     'perl-modules',


### PR DESCRIPTION
Should fix this error:

```
git: error while loading shared libraries: libcrypto.so.0.9.8: cannot open shared object file: No such file or directory
```
