### PR TITLE
git: add receive.advertiseAlternates config option

### DIFF
--- a/packages/git/formula.rb
+++ b/packages/git/formula.rb
@@ -5,7 +5,7 @@ class Git < DebianFormula
 
   section 'vcs'
   name 'git'
-  version '1:1.7.5.4-1+github8'
+  version '1:1.7.5.4-1+github9'
   description <<-DESC
     The Git DVCS with custom patches and bugfixes for GitHub.
   DESC
@@ -41,6 +41,9 @@ class Git < DebianFormula
 
       # eliminate duplicate .have refs
       'patches/remove-duplicate-dot-have-lines.patch',
+
+      # allow turning off .have lines entirely
+      'patches/receive-pack-advertise-alternates.patch',
 
       # speed up git-fetch with large number of refs
       'patches/git-fetch-performance.patch',

--- a/packages/git/patches/receive-pack-advertise-alternates.patch
+++ b/packages/git/patches/receive-pack-advertise-alternates.patch
@@ -1,0 +1,65 @@
+From 88c91fcd2c276623d79447b215bca02641d64dfa Mon Sep 17 00:00:00 2001
+From: Jeff King <peff@peff.net>
+Date: Wed, 4 Jan 2012 09:28:23 -0500
+Subject: [PATCH] receive-pack: respect receive.advertiseAlternates config
+
+Usually receive-pack advertises ref tips from alternates
+repositories so that clients can sometimes avoid sending
+objects that are already upstream.
+
+However, if you have a very large alternates network, then
+the number of ".have" refs can get cumbersome, and you spend
+more time advertising refs that the client doesn't care
+about than you are saving in the optimization.
+
+This patch adds a config variable to drop .have lines
+entirely.
+
+An alternative approach would be to restrict the .have lines
+to a smaller portion of the namespace that is known to be
+"interesting" to most clients. This patch is much simpler;
+if the loss of the .have optimization turns out to be too
+much, we can try something more complex.
+
+Signed-off-by: Jeff King <peff@peff.net>
+---
+ builtin/receive-pack.c |    9 ++++++++-
+ 1 files changed, 8 insertions(+), 1 deletions(-)
+
+diff --git a/builtin/receive-pack.c b/builtin/receive-pack.c
+index e1ba4dc..69e8e8a 100644
+--- a/builtin/receive-pack.c
++++ b/builtin/receive-pack.c
+@@ -35,6 +35,7 @@ static int auto_update_server_info;
+ static int auto_gc = 1;
+ static const char *head_name;
+ static int sent_capabilities;
++static int advertise_alternates = 1;
+ 
+ static enum deny_action parse_deny_action(const char *var, const char *value)
+ {
+@@ -103,6 +104,11 @@ static int receive_pack_config(const char *var, const char *value, void *cb)
+ 		return 0;
+ 	}
+ 
++	if (strcmp(var, "receive.advertisealternates") == 0) {
++		advertise_alternates = git_config_bool(var, value);
++		return 0;
++	}
++
+ 	return git_default_config(var, value, cb);
+ }
+ 
+@@ -790,7 +796,8 @@ int cmd_receive_pack(int argc, const char **argv, const char *prefix)
+ 		unpack_limit = receive_unpack_limit;
+ 
+ 	if (advertise_refs || !stateless_rpc) {
+-		add_alternate_refs();
++		if (advertise_alternates)
++			add_alternate_refs();
+ 		write_head_info();
+ 		clear_extra_refs();
+ 
+-- 
+1.7.8.2.6.g2e4b88
+


### PR DESCRIPTION
This should let us drop the excessively long ".have" lists
you get when pushing to heavily-forked repos.

See github/github #2401 for an example of why this is a problem.
