### PR TITLE
git: detect clones more accurately in upload-pack patch

### DIFF
--- a/packages/git/formula.rb
+++ b/packages/git/formula.rb
@@ -5,7 +5,7 @@ class Git < DebianFormula
 
   section 'vcs'
   name 'git'
-  version '1:1.7.5.4-1+github9'
+  version '1:1.7.5.4-1+github10'
   description <<-DESC
     The Git DVCS with custom patches and bugfixes for GitHub.
   DESC

--- a/packages/git/patches/post-upload-pack-hook.patch
+++ b/packages/git/patches/post-upload-pack-hook.patch
@@ -24,10 +24,10 @@ index ce5cbbe..851558f 100644
  	return 0;
  }
  
-+static void run_post_upload_pack_hook(int create_full_pack)
++static void run_post_upload_pack_hook(int is_clone)
 +{
 +	const char *fetch_type;
-+	fetch_type = (create_full_pack) ? "clone" : "fetch";
++	fetch_type = (is_clone) ? "clone" : "fetch";
 +	run_hook(NULL, "post-upload-pack", fetch_type, NULL);
 +}
 +
@@ -39,7 +39,7 @@ index ce5cbbe..851558f 100644
  	if (use_sideband)
  		packet_flush(1);
 +
-+	run_post_upload_pack_hook(create_full_pack);
++	run_post_upload_pack_hook(!have_obj.nr);
  	return;
  
   fail:


### PR DESCRIPTION
This should fix github/github#2116.

We keep statistics on clones versus fetches by asking
upload-pack to run a hook for us. It tells us which it saw
by checking git's existing create_full_pack flag. However,
that flag is intended for use by pack-objects and is defined
like this:

   int create_full_pack = (nr_our_refs == want_obj.nr && !have_obj.nr);

I.e., the other side asked for everything we had, and
claimed to have nothing else. But the first half of the
condition is not true for most GitHub repositories, as we
have refs outside of refs/heads and refs/tags that are not
fetched by normal, non-mirror clones (e.g., our pull request
refs).

A better heuristic for clone vs fetch is to just take the
second half of that condition: check that the remote side
claimed not to have any objects in its repository. That will
catch clones and fetches into empty repositories, both of
which are identical from the server's perspective.

It will miss a clone with "--reference" to an alternates
repository. But that is a minority case, and arguably not
really a clone (it's indistinguishable on the server end
from a fetch from a related repository cloned from somewhere
else).
