### PR TITLE
MaxMind requires HTTPS for downloads

### DIFF
--- a/packages/geoip/formula.rb
+++ b/packages/geoip/formula.rb
@@ -5,7 +5,7 @@ class GeoIPCityDB < DebianFormula
   VERSION = "GeoIP-#{EDITION}_#{DATE}"
 
   homepage 'http://www.maxmind.com/app/city'
-  url "http://download.maxmind.com/app/geoip_download?edition_id=#{EDITION}&date=#{DATE}&suffix=tar.gz&license_key=#{LICENSE}"
+  url "https://download.maxmind.com/app/geoip_download?edition_id=#{EDITION}&date=#{DATE}&suffix=tar.gz&license_key=#{LICENSE}"
   md5 '100f82fea1a6a12d5e8494dcb8c13305'
 
   name 'geoip-city'


### PR DESCRIPTION
MaxMind will be requiring HTTPS for all database download requests starting in March 2024.

See [this release note](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023).